### PR TITLE
fixing some bugs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "dependencies": {
     "babel-cli": "^6.0.0",
     "babel-preset-es2015": "*",
-    "ripple-lib": "*",
+    "command-line-args": "^3.0.1",
+    "command-line-usage": "^3.0.3",
     "ws": "^1.1.1"
   },
   "babel": {
@@ -16,9 +17,6 @@
     ]
   },
   "devDependencies": {
-    "eslint": "*",
-    "command-line-args": "^3.0.1",
-    "command-line-usage": "^3.0.3",
-    "ws": "^1.1.1"
+    "eslint": "*"
   }
 }

--- a/server/ws-server.js
+++ b/server/ws-server.js
@@ -45,10 +45,11 @@ Server = (function () {
                 console.log('Server '+port+' received: "%s"', message);
             });
 
-            self.ws.send('Server at '+port+' says: Hello');
+            self.ws.send('Server at '+port+' says: Hello', function () {});
 
             setInterval(function(){
-                self.ws.send('Server at '+port+' says: Hello');
+                // If a callback isn't specified, and a client gets killed without calling the close function the server crashes.
+                self.ws.send('Server at '+port+' says: Hello', function(){});
             }, 2000);
 
             cb(self);


### PR DESCRIPTION
When a callback isnt sent with a ws.send(), and the client receiving the message crashes or closes without calling ws.close, then the server crashes.

Added a empty callback to avoid this.
